### PR TITLE
Add recipe support

### DIFF
--- a/src/main/java/qinomed/kubejsdelight/KubeJSDelightPlugin.java
+++ b/src/main/java/qinomed/kubejsdelight/KubeJSDelightPlugin.java
@@ -2,9 +2,13 @@ package qinomed.kubejsdelight;
 
 import dev.latvian.mods.kubejs.KubeJSPlugin;
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.recipe.RegisterRecipeTypesEvent;
+import net.minecraft.resources.ResourceLocation;
 import qinomed.kubejsdelight.block.custom.FeastBlockBuilder;
 import qinomed.kubejsdelight.item.custom.KnifeItemBuilder;
 import qinomed.kubejsdelight.block.custom.PieBlockBuilder;
+import qinomed.kubejsdelight.recipe.CookingRecipeJS;
+import qinomed.kubejsdelight.recipe.CuttingRecipeJS;
 
 public class KubeJSDelightPlugin extends KubeJSPlugin {
     @Override
@@ -12,5 +16,11 @@ public class KubeJSDelightPlugin extends KubeJSPlugin {
         RegistryObjectBuilderTypes.ITEM.addType("knife", KnifeItemBuilder.class, KnifeItemBuilder::new);
         RegistryObjectBuilderTypes.BLOCK.addType("pie", PieBlockBuilder.class, PieBlockBuilder::new);
         RegistryObjectBuilderTypes.BLOCK.addType("feast", FeastBlockBuilder.class, FeastBlockBuilder::new);
+    }
+
+    @Override
+    public void registerRecipeTypes(RegisterRecipeTypesEvent event) {
+        event.register(new ResourceLocation("farmersdelight:cutting"), CuttingRecipeJS::new);
+        event.register(new ResourceLocation("farmersdelight:cooking"), CookingRecipeJS::new);
     }
 }

--- a/src/main/java/qinomed/kubejsdelight/recipe/CookingRecipeJS.java
+++ b/src/main/java/qinomed/kubejsdelight/recipe/CookingRecipeJS.java
@@ -1,0 +1,146 @@
+package qinomed.kubejsdelight.recipe;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.core.ItemStackKJS;
+import dev.latvian.mods.kubejs.item.ItemStackJS;
+import dev.latvian.mods.kubejs.recipe.*;
+import dev.latvian.mods.kubejs.util.ListJS;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
+import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
+import vectorwing.farmersdelight.common.registry.ModRecipeSerializers;
+
+import java.util.List;
+
+public class CookingRecipeJS extends RecipeJS {
+    public static RecipeSerializer<CookingPotRecipe> serializer = (RecipeSerializer<CookingPotRecipe>) ModRecipeSerializers.COOKING.get();
+    private CookingPotRecipe recipe = null;
+
+    @Override
+    public void create(RecipeArguments args) {
+        recipe = new CookingPotRecipe(
+                getOrCreateId(),
+                "",
+                null,
+                parseItemInputListNN(args.get(0)),
+                parseItemOutput(args.get(1)),
+                parseItemOutput(args.get(2)),
+                args.getFloat(3, 0),
+                args.getInt(4, 1)
+        );
+    }
+
+    public NonNullList<Ingredient> parseItemInputListNN(Object obj) {
+        NonNullList<Ingredient> nlist = NonNullList.create();
+        nlist.addAll(parseItemInputList(obj));
+        return nlist;
+    }
+
+    @Override
+    public void deserialize() {
+        recipe = serializer.fromJson(getOrCreateId(), json);
+    }
+
+    @Override
+    public void serialize() {
+        JsonArray arrayIngredients = new JsonArray();
+
+        for (Ingredient ingredient : recipe.getIngredients()) {
+            arrayIngredients.add(ingredient.toJson());
+        }
+        json.add("ingredients", arrayIngredients);
+
+        JsonObject objectResult = new JsonObject();
+        var result = recipe.getResultItem();
+        objectResult.addProperty("item", ((ItemStackKJS)(Object)(result)).kjs$getId().toString());
+        if (result.getCount() > 1) {
+            objectResult.addProperty("count", result.getCount());
+        }
+        json.add("result", objectResult);
+
+        var container = recipe.getOutputContainer();
+        if (container != null) {
+            JsonObject objectContainer = new JsonObject();
+            objectContainer.addProperty("item", ((ItemStackKJS)(Object)(container)).kjs$getId().toString());
+            json.add("container", objectContainer);
+        }
+        if (recipe.getExperience() > 0) {
+            json.addProperty("experience", recipe.getExperience());
+        }
+        json.addProperty("cookingtime", recipe.getCookTime());
+    }
+
+    @Override
+    public boolean hasInput(IngredientMatch match) {
+        var ings = recipe.getIngredients();
+        for (Ingredient ing : ings) {
+            if (match.contains(ing)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean replaceInput(IngredientMatch match, Ingredient with, ItemInputTransformer transformer) {
+        var ings = recipe.getIngredients();
+        var changed = false;
+        for (int i = 0; i < ings.size(); i++) {
+            var ing = ings.get(i);
+            if (match.contains(ing)) {
+                ings.set(i, transformer.transform(this, match, ing, with));
+                changed = true;
+            }
+        }
+        if (changed) {
+            recipe = new CookingPotRecipe(
+                    getOrCreateId(),
+                    "",
+                    null,
+                    ings,
+                    recipe.getResultItem(),
+                    recipe.getOutputContainer(),
+                    recipe.getExperience(),
+                    recipe.getCookTime()
+            );
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean hasOutput(IngredientMatch match) {
+        return match.contains(recipe.getResultItem()) || match.contains(recipe.getOutputContainer());
+    }
+
+    @Override
+    public boolean replaceOutput(IngredientMatch match, ItemStack with, ItemOutputTransformer transformer) {
+        var changed = false;
+        ItemStack result = recipe.getResultItem();
+        if (match.contains(result)) {
+            result = transformer.transform(this, match, result, with);
+            changed = true;
+        }
+        ItemStack container = recipe.getOutputContainer();
+        if (match.contains(container)) {
+            container = transformer.transform(this, match, container, with);
+            changed = true;
+        }
+        if (changed) {
+            recipe = new CookingPotRecipe(
+                    getOrCreateId(),
+                    "",
+                    null,
+                    recipe.getIngredients(),
+                    result,
+                    container,
+                    recipe.getExperience(),
+                    recipe.getCookTime()
+            );
+        }
+        return changed;
+    }
+}

--- a/src/main/java/qinomed/kubejsdelight/recipe/CuttingRecipeJS.java
+++ b/src/main/java/qinomed/kubejsdelight/recipe/CuttingRecipeJS.java
@@ -1,0 +1,148 @@
+package qinomed.kubejsdelight.recipe;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.core.ItemStackKJS;
+import dev.latvian.mods.kubejs.item.ItemStackJS;
+import dev.latvian.mods.kubejs.recipe.*;
+import dev.latvian.mods.kubejs.util.ListJS;
+import dev.latvian.mods.kubejs.util.MapJS;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
+import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
+import vectorwing.farmersdelight.common.crafting.ingredient.ChanceResult;
+import vectorwing.farmersdelight.common.registry.ModRecipeSerializers;
+
+public class CuttingRecipeJS extends RecipeJS {
+    public static RecipeSerializer<CuttingBoardRecipe> serializer = (RecipeSerializer<CuttingBoardRecipe>) ModRecipeSerializers.CUTTING.get();
+    private CuttingBoardRecipe recipe = null;
+    @Override
+    public void create(RecipeArguments args) {
+        recipe = new CuttingBoardRecipe(
+                getOrCreateId(),
+                "",
+                parseItemInput(args.get(0)),
+                parseItemInput(args.get(1)),
+                parseItemOutputListWithChance(args.get(2)),
+                args.getString(3, "")
+        );
+    }
+
+    public NonNullList<ChanceResult> parseItemOutputListWithChance(Object obj) {
+        NonNullList<ChanceResult> list = NonNullList.create();
+
+        for (var ele : ListJS.orSelf(obj)) {
+            JsonObject map = MapJS.json(ele);
+            if (map != null && map.has("chance")) {
+                list.add(new ChanceResult(ItemStackJS.of(ele), map.get("chance").getAsFloat()));
+            } else {
+                list.add(new ChanceResult(ItemStackJS.of(ele), 1F));
+            }
+        }
+
+        return list;
+    }
+
+    @Override
+    public void deserialize() {
+        recipe = serializer.fromJson(getOrCreateId(), json);
+    }
+
+    @Override
+    public void serialize() {
+        JsonArray arrayIngredients = new JsonArray();
+        arrayIngredients.add(recipe.getIngredients().get(0).toJson());
+        json.add("ingredients", arrayIngredients);
+
+        json.add("tool", recipe.getTool().toJson());
+
+        JsonArray arrayResults = new JsonArray();
+        for (ChanceResult result : recipe.getRollableResults()) {
+            JsonObject jsonobject = new JsonObject();
+            jsonobject.addProperty("item", ((ItemStackKJS)(Object)(result.getStack())).kjs$getId().toString());
+            if (result.getStack().getCount() > 1) {
+                jsonobject.addProperty("count", result.getStack().getCount());
+            }
+            if (result.getChance() < 1) {
+                jsonobject.addProperty("chance", result.getChance());
+            }
+            arrayResults.add(jsonobject);
+        }
+        json.add("result", arrayResults);
+        if (!recipe.getSoundEventID().isEmpty()) {
+            json.addProperty("sound", recipe.getSoundEventID());
+        }
+    }
+
+    @Override
+    public boolean hasInput(IngredientMatch match) {
+        return match.contains(recipe.getIngredients().get(0));
+    }
+
+    @Override
+    public boolean replaceInput(IngredientMatch match, Ingredient with, ItemInputTransformer transformer) {
+        var ings = recipe.getIngredients();
+        var changed = false;
+        for (int i = 0; i < ings.size(); i++) {
+            var ing = ings.get(i);
+            if (match.contains(ing)) {
+                ings.set(i, transformer.transform(this, match, ing, with));
+                changed = true;
+            }
+        }
+        var tool = recipe.getTool();
+        if (match.contains(tool)) {
+            tool = transformer.transform(this, match, tool, with);
+            changed = true;
+        }
+        if (changed) {
+            recipe = new CuttingBoardRecipe(
+                    getOrCreateId(),
+                    "",
+                    ings.get(0),
+                    tool,
+                    recipe.getRollableResults(),
+                    recipe.getSoundEventID()
+            );
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean hasOutput(IngredientMatch match) {
+        var results = recipe.getResults();
+        for (var res : results) {
+            if (match.contains(res)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean replaceOutput(IngredientMatch match, ItemStack with, ItemOutputTransformer transformer) {
+        var changed = false;
+        var results = recipe.getRollableResults();
+        for (int i = 0; i < results.size(); i++) {
+            var result = results.get(i);
+            if (match.contains(result.getStack())) {
+                results.set(i, new ChanceResult(transformer.transform(this, match, result.getStack(), with), result.getChance()));
+                changed = true;
+            }
+        }
+        if (changed) {
+            recipe = new CuttingBoardRecipe(
+                    getOrCreateId(),
+                    "",
+                    recipe.getIngredients().get(0),
+                    recipe.getTool(),
+                    results,
+                    recipe.getSoundEventID()
+            );
+        }
+        return changed;
+    }
+}


### PR DESCRIPTION
Examples:
```js
ServerEvents.recipes(event => {
	// Change recipes here

	event.recipes.farmersdelight.cutting(
        "minecraft:cobblestone",
        "#forge:tools/pickaxes", // tool
        [ // results
            "minecraft:iron_ore",
            {
                item: "minecraft:diamond",
                chance: 0.8
            }
        ],
        "" // sound
	)

	event.recipes.farmersdelight.cooking(
	    ["minecraft:cobblestone"],
	    "minecraft:iron_ore", // output
	    "minecraft:bowl", // container
	    30, // exp
	    10, // cookTime
	)
})
```